### PR TITLE
Support FOX ERC-20 token

### DIFF
--- a/packages/contracts/networks/1/FOX/RealityETH_ERC20-2.0.json
+++ b/packages/contracts/networks/1/FOX/RealityETH_ERC20-2.0.json
@@ -1,0 +1,9 @@
+{
+    "address": "0xf4585A9944A390615E7cec6756C1c082173B93eB",
+    "block": 12821080,
+    "token_address": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
+    "notes": null,
+    "arbitrators": {
+        "0x90A48D5CF7343B08dA12E067680B4C6dbfE551Be": "ShapeShift DAO"
+    }
+}

--- a/packages/contracts/tokens/FOX.json
+++ b/packages/contracts/tokens/FOX.json
@@ -1,0 +1,7 @@
+{
+    "decimals": 1000000000000000000,
+    "small_number": 1000000000000000000,
+    "erc20_networks": {
+        "1": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d"
+    }
+}


### PR DESCRIPTION
We'd like to add the FOX token to reality.eth.link for use with the [new ShapeShift DAO](https://shapeshift.com/shapeshift-decentralize-airdrop)!

