### PR TITLE
Template Builder - Avoid redirecting in Details page (fix)

### DIFF
--- a/packages/template-generator/src/components/Header/Header.tsx
+++ b/packages/template-generator/src/components/Header/Header.tsx
@@ -8,7 +8,7 @@ import { Link } from "react-router-dom";
 
 export const Header = () => {
   const chainId = useChainId();
-  const label = getNetworkLabel(chainId);
+  const label = chainId ? getNetworkLabel(chainId) : "";
 
   return (
     <div>

--- a/packages/template-generator/src/components/forms/InstanceForm/InstanceField.tsx
+++ b/packages/template-generator/src/components/forms/InstanceForm/InstanceField.tsx
@@ -32,7 +32,7 @@ export function InstanceField({
   const chainId = useChainId();
 
   const options = useMemo(() => {
-    const instances = getRealityETHInstances(chainId);
+    const instances = getRealityETHInstances(chainId || 1);
     return instances.map((instance) => ({
       label: `${instance.token} - ${shortAddress(instance.address)}`,
       value: instance.address,

--- a/packages/template-generator/src/hooks/useChainId.ts
+++ b/packages/template-generator/src/hooks/useChainId.ts
@@ -3,7 +3,9 @@ import { useProvider } from "./useProvider";
 
 export function useChainId() {
   const provider = useProvider();
-  const [chainId, setChainId] = useState(provider.network?.chainId || 1);
+  const [chainId, setChainId] = useState<number | undefined>(
+    provider.network?.chainId
+  );
 
   useEffect(() => {
     provider.on("network", (network) => {


### PR DESCRIPTION
If the provider is not the expected for the template, we shouldn't redirect the user to the home page.