### PR TITLE
[fix] Return latest version (v3) on realityETHConfig function

### DIFF
--- a/packages/contracts/index.js
+++ b/packages/contracts/index.js
@@ -78,7 +78,7 @@ function tokenConfig(token, chain_id) {
 }
 
 function realityETHConfig(chain_id, token, version) {
-    const versions = ['2.1', '2.1-rc1', '2.0', '3.0'];
+    const versions = ['3.0', '2.1', '2.1-rc1', '2.0'];
     const token_info = chainTokenList(chain_id);
     if (!token_info[token]) {
         console.log("Token not found for chain");
@@ -118,7 +118,7 @@ function realityETHConfig(chain_id, token, version) {
 
 function realityETHConfigs(chain_id, token) {
     let configs = {};
-    const versions = ['2.1', '2.1-rc1', '2.0', '3.0'];
+    const versions = ['3.0', '2.1', '2.1-rc1', '2.0'];
     const token_info = chainTokenList(chain_id);
     if (!token_info[token]) {
         console.log("Token not found for network");


### PR DESCRIPTION
### Summary
The Template Generator uses the `realityETHConfig` function to get the latest version of the RealityETH contract, currently it keeps showing the V2.1 version of the contract.

### Fix
The `realityETHConfig` gets the latest version by iterating on the `versions` array, declared within the function, this versions array is assume to be sorted from latest to oldest.
By just moving the `3.0` version from the end to the beginning of the array, the issue is fixed.